### PR TITLE
Highting parameters with defaults and keyword arguments

### DIFF
--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -44,6 +44,7 @@
 (parameters (typed_parameter (identifier) @variable.parameter))
 (parameters (default_parameter name: (identifier) @variable.parameter))
 (parameters (typed_default_parameter name: (identifier) @variable.parameter))
+(keyword_argument name: (identifier) @variable.parameter)
 
 ; Types
 

--- a/runtime/queries/python/highlights.scm
+++ b/runtime/queries/python/highlights.scm
@@ -42,6 +42,8 @@
 
 (parameters (identifier) @variable.parameter)
 (parameters (typed_parameter (identifier) @variable.parameter))
+(parameters (default_parameter name: (identifier) @variable.parameter))
+(parameters (typed_default_parameter name: (identifier) @variable.parameter))
 
 ; Types
 


### PR DESCRIPTION
This resolves the issue you pointed out with parameters.

As for the other issue with None in a type hint, I couldn't replicate the issue you had. If I increased the nesting another 3 times it did the correct highlighting, so it seems to me like it is just due to nesting depth so expected behaviour. I'm keeping the nesting depth as it was because I suspect for most use cases this will be sufficient. Experience with it will tell if we need to increase more though.